### PR TITLE
Add --promote flag to gcloud app deploy command by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ deploy - ship version of code to Google Cloud App Engine
 
 **Environment Variables:**
 
-GCAPPENGINE_JSON_USER (Required)  the contents of a service account json created from Google's Instructions [here](https://cloud.google.com/iam/docs/service-accounts)  NOTE: this is json content, not a uri to a file.
+GCAPPENGINE_USER_JSON (Required)  the contents of a service account json created from Google's Instructions [here](https://cloud.google.com/iam/docs/service-accounts)  NOTE: this is json content, not a uri to a file.
 
 CLOUDSDK_CORE_PROJECT (Required)  project name as displayed in google cloud
 

--- a/flow/cloud/gcappengine/gcappengine.py
+++ b/flow/cloud/gcappengine/gcappengine.py
@@ -161,7 +161,7 @@ class GCAppEngine(Cloud):
         method = '_gcloud_deploy'
         commons.print_msg(GCAppEngine.clazz, method, 'begin')
 
-        promote_flag = "--no-promote" if promote is False else ""
+        promote_flag = "--no-promote" if promote is False else "--promote"
         cmd = "{path}gcloud app deploy {dir}/{env} --quiet --version {ver} {promote}".format(
             path=GCAppEngine.path_to_google_sdk,
             dir=self.config.push_location,

--- a/tests/cloud/gcappengine/test_gcappengine.py
+++ b/tests/cloud/gcappengine/test_gcappengine.py
@@ -98,4 +98,4 @@ def test_promote(monkeypatch):
             _gcAppEngine = GCAppEngine(config_override=_b)
             _gcAppEngine._gcloud_deploy('dummy.yml', promote=True)
 
-        mock_printmsg_fn.assert_any_call('GCAppEngine', '_gcloud_deploy', 'gcloud app deploy fordeployment/dummy.yml --quiet --version v1-0-0 ')
+        mock_printmsg_fn.assert_any_call('GCAppEngine', '_gcloud_deploy', 'gcloud app deploy fordeployment/dummy.yml --quiet --version v1-0-0 --promote')


### PR DESCRIPTION
The default behavior of the PROMOTE flag to the `flow gcappengine` is
true as stated in the README. However, the current behavior didn't add
the `--promote` flag to the built `gcloud app deploy` command.

This commit adds the `--promote` flag whenever it is set to true.

Also fix a documentation error in the README, the proper enviroment
variable is `GCAPPENGINE_USER_JSON` not `GCAPPENGINE_JSON_USER`.

Fixes [#19]