### PR TITLE
increase artifactory timeout to 60s

### DIFF
--- a/flow/artifactstorage/artifactory/artifactory.py
+++ b/flow/artifactstorage/artifactory/artifactory.py
@@ -33,7 +33,7 @@ class Artifactory(Artifact_Storage):
     pom_filename = None
     pom_file = None
     config = BuildConfig
-    http_timeout = 30
+    http_timeout = 60
 
     def __init__(self, config_override=None):
         method = '__init__'


### PR DESCRIPTION
We are seeing intermittent reports of timeouts during uploads to artifactory.

This PR is to double the timeout for artifactory operations from 30s to 60s.