### PR TITLE
support uploading to artifactory

### DIFF
--- a/scripts/buildwheel.sh
+++ b/scripts/buildwheel.sh
@@ -4,6 +4,10 @@ source "../ci/scripts/flow-env.sh"
 
 flow github -o VERSION getversion $ENVIRONMENT
 
+pip3 install setuptools==38.5.2
+pip3 install twine==1.10.0
+pip3 install wheel==0.30.0
+
 python3 setup.py bdist_wheel
 
 twine upload --config-file scripts/.pypirc -r local -u $PYPI_USER -p $PYPI_PWD dist/*


### PR DESCRIPTION
The twine upload step to artifactory fails due to [this issue](https://github.com/pypa/twine/issues/341).

This change is to specifically peg to a certain version of twine, wheel, and setuptools that will mitigate this issue until artifactory properly supports Metadata 2.1 packaged uploads