### PR TITLE
Update tracker.py

### DIFF
--- a/flow/projecttracking/tracker/tracker.py
+++ b/flow/projecttracking/tracker/tracker.py
@@ -145,7 +145,7 @@ class Tracker(Project_Tracking):
             else:
                 commons.print_msg(Tracker.clazz, method, resp.text)
         except requests.ConnectionError:
-            commons.print_msg(Tracker.clazz, method, 'Request to Tracker timed out.', 'WARN')
+            commons.print_msg(Tracker.clazz, method, 'Connection error. ' + str(e), 'WARN')
         except Exception as e:
             commons.print_msg(Tracker.clazz, method, "Unable to tag story {story} with label {lbl}".format(
                 story=story_id, lbl=label), 'WARN')


### PR DESCRIPTION
The current error "Request to Tracker timed out." is not always correct and can hide a real error.