### PR TITLE
Do not pass the `-d` flag to cf push.

### DIFF
--- a/flow/cloud/cloudfoundry/cloudfoundry.py
+++ b/flow/cloud/cloudfoundry/cloudfoundry.py
@@ -254,16 +254,13 @@ class CloudFoundry(Cloud):
             file_to_push = "{dir}/{file}".format(dir=self.config.push_location, file=self.find_deployable(
                 self.config.artifact_extension, self.config.push_location))
 
-        domain = "-d {}".format(CloudFoundry.cf_domain) if CloudFoundry.cf_domain is not None else ""
         buildpack = "-b {}".format(os.getenv('CF_BUILDPACK')) if os.getenv('CF_BUILDPACK') else ""
 
-        cmd = CloudFoundry.path_to_cf + "cf push {project_name}-{version} -p {pushlocation} -f {manifest} {buildpack} " \
-                                        "{cf_domain}".format(project_name=self.config.project_name,
-                                                               version=self.config.version_number,
-                                                               pushlocation=file_to_push,
-                                                               manifest=manifest,
-                                                               buildpack=buildpack,
-                                                               cf_domain=domain)
+        cmd = CloudFoundry.path_to_cf + "cf push {project_name}-{version} -p {pushlocation} -f {manifest} {buildpack} ".format(project_name=self.config.project_name,
+                                            version=self.config.version_number,
+                                            pushlocation=file_to_push,
+                                            manifest=manifest,
+                                            buildpack=buildpack)
 
         commons.print_msg(CloudFoundry.clazz, method, cmd.split())
         cf_push = subprocess.Popen(cmd.split(), shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
There have been some deprecations in the latest CF CLI as described
Here: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated

Essentially, using a combination of the `-d` flag while having routes
Specified in the manifest, results in the following error:

```bash
[DEBUG] CloudFoundry  _cf_push                            ['./cf', 'push', ‘App-v0.24.0+6', '-p', 'fordeployment', '-f', 'acceptance.manifest.yml', '-d', ‘my-custom-url.domain.com’]
[DEBUG] CloudFoundry  _cf_push                            Pushing from manifest to org organization / space acceptance as user…
[DEBUG] CloudFoundry  _cf_push                            Using manifest file acceptance.manifest.yml
[DEBUG] CloudFoundry  _cf_push                            The following arguments cannot be used with an app manifest that declares routes using the 'route' attribute: -d, --hostname, -n, --no-hostname, --route-path
[DEBUG] CloudFoundry  _cf_push                            FAILED
[DEBUG] CloudFoundry  _cf_push                            
[ERROR] CloudFoundry  _cf_push                            Failed calling ./cf push App-v0.24.0+6 -p fordeployment -f acceptance.manifest.yml  -d my-custom-url.domain.com.  Return code of 1.
```

This fixes this issue.