### PR TITLE
remove code to set story_release_notes to None

### DIFF
--- a/flow/projecttracking/jira/jira.py
+++ b/flow/projecttracking/jira/jira.py
@@ -405,9 +405,6 @@ class Jira(Project_Tracking):
             story_release_note_summary['description'] = description_text
             story_release_notes.append(story_release_note_summary)
 
-        if len(story_release_notes) == 0:
-            story_release_notes = None
-
         commons.print_msg(Jira.clazz, method, story_release_notes)
         commons.print_msg(Jira.clazz, method, 'end')
         return story_release_notes

--- a/flow/projecttracking/tracker/tracker.py
+++ b/flow/projecttracking/tracker/tracker.py
@@ -267,9 +267,6 @@ class Tracker(Project_Tracking):
             story_release_note_summary['url'] = story.get('url')
             story_release_note_summary['current_state'] = story.get('current_state')
             story_release_notes.append(story_release_note_summary)
-        
-        if len(story_release_notes) == 0:
-            story_release_notes = None
 
         commons.print_msg(Tracker.clazz, method, story_release_notes)
         commons.print_msg(Tracker.clazz, method, 'end')

--- a/tests/projecttracking/jira/test_jira.py
+++ b/tests/projecttracking/jira/test_jira.py
@@ -1041,7 +1041,7 @@ def test_flatten_story_details_with_empty_story_details(monkeypatch):
         _jira = Jira(config_override=_b)
 
         flat_story_details = _jira.flatten_story_details([])
-        assert flat_story_details is None
+        assert len(flat_story_details) == 0
 
 def test_flatten_story_details_with_story_details(monkeypatch):
     monkeypatch.setenv('JIRA_USER', 'flow_tester@homedepot.com')

--- a/tests/projecttracking/tracker/test_tracker.py
+++ b/tests/projecttracking/tracker/test_tracker.py
@@ -544,7 +544,7 @@ def test_flatten_story_details_with_empty_story_details(monkeypatch):
     _tracker = Tracker(config_override=_b)
 
     flat_story_details = _tracker.flatten_story_details([])
-    assert flat_story_details is None
+    assert len(flat_story_details) == 0
 
 def test_flatten_story_details_with_story_details(monkeypatch):
     monkeypatch.setenv('TRACKER_TOKEN', 'fake_token')


### PR DESCRIPTION
It appears that the current implementation causes an error during slack release notes publishing:

```
[DEBUG] Slack        publish_deployment                  begin
[DEBUG] Slack        _get_manual_deploy_links            No manual build links specified
Traceback (most recent call last):
  File "/usr/local/bin/flow", line 11, in <module>
    load_entry_point('THD-Flow', 'console_scripts', 'flow')()
  File "/tmp/build/d6654116/code-repo/flow/aggregator.py", line 175, in main
    slack.publish_deployment(story_details)
  File "/tmp/build/d6654116/code-repo/flow/communications/slack/slack.py", line 107, in publish_deployment
    if len(story_details) == 0:
TypeError: object of type 'NoneType' has no len()
```

This change removes the logic to set `story_release_notes` explicitly to `None` when there are no stories and instead leaves it set to an empty array as was [done before](https://github.com/homedepot/flow/blob/beef923267b0ea80b89163a18317264fc5e9c3c8/flow/projecttracking/tracker/tracker.py#L82-L93).

