### PR TITLE
Failed CF Push creates "empty" App

### DIFF
--- a/flow/cloud/cloudfoundry/cloudfoundry.py
+++ b/flow/cloud/cloudfoundry/cloudfoundry.py
@@ -24,7 +24,6 @@ class CloudFoundry(Cloud):
     path_to_cf = None
     stopped_apps = None
     started_apps = None
-    deployed_app = None
     config = BuildConfig
     http_timeout = 30
 
@@ -483,6 +482,7 @@ class CloudFoundry(Cloud):
 
         if push_failed:
             os.system('stty sane')
+            commons.print_msg(CloudFoundry.clazz, method, 'Deleting failed deployment {app}'.format(app=new_app_name))
             self._start_stop_delete_app(new_app_name, 'delete')
             self._cf_logout()
             exit(1)
@@ -832,8 +832,11 @@ class CloudFoundry(Cloud):
             new_app_name = "{project_name}-{version}".format(project_name=self.config.project_name,
                                                              version=self.config.version_number)
             for line in CloudFoundry.stopped_apps.splitlines():
-                if line != new_app_name:
+                if line.decode("utf-8").lower() != new_app_name.lower():
                     previous_versions.append(line.decode("utf-8"))
+                else:
+                    commons.print_msg(CloudFoundry.clazz, method,
+                                      '{app} is version that just deployed'.format(app=new_app_name))
             self._unmap_modify_app_state_versions(previous_versions, 'delete')
 
         commons.print_msg(CloudFoundry.clazz, method, 'DEPLOYMENT SUCCESSFUL')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyDispatcher==2.0.5
 requests>=2.20.0
 pytest==2.9.2
-pytest-cov==2.3.0
+pytest-cov==2.12.1
 responses==0.8.1
 pytest-mock==1.2


### PR DESCRIPTION
Fixes #78 

Changes:
1. We now pull the new App name before doing a `cf push` command. In the event that `cf push` command fails to execute successfully, we pass that App name to the `_start_stop_delete_app()` function to clean up after the CF CLI. 
2. During the cleanup portion of the `flow cf deploy` command, when the previous version (just the list of "Stopped" Apps) of the App are interrogated, we check if the App name is equal to the name of the App we just deployed. If it isn't, we allow its deletion, otherwise we explicitly state we do not delete it.
3. Updated `pytest-cov` version to stop an error when running tests. 

**Note** - This portion of the code is not heavily tested. It is also somewhat tightly coupled which makes writing new tests more difficult. 