### PR TITLE
Update jira.py to accept projectKeys with numeric

### DIFF
--- a/flow/projecttracking/jira/jira.py
+++ b/flow/projecttracking/jira/jira.py
@@ -357,7 +357,7 @@ class Jira(Project_Tracking):
                     # verify there isn't a embedded bracket, if so just skip this one and keep marching.
                     if stories.find('[') == -1:  # there is a nested starting bracket
                         # now dig out the tracker number or jira key in single number format or multiple separated by commas.
-                        r = re.compile('(?:[a-zA-Z]+\-[0-9]+,?)+(,([a-zA-Z]+\-[0-9]+,?))*,?')
+                        r = re.compile('(?:[a-zA-Z0-9]+\-[0-9]+,?)+(,([a-zA-Z0-9]+\-[0-9]+,?))*,?'
                         stories_array = stories.split(',')
                         stories = list(filter(r.match, stories_array))
                         for story in stories:

--- a/flow/projecttracking/jira/jira.py
+++ b/flow/projecttracking/jira/jira.py
@@ -357,7 +357,7 @@ class Jira(Project_Tracking):
                     # verify there isn't a embedded bracket, if so just skip this one and keep marching.
                     if stories.find('[') == -1:  # there is a nested starting bracket
                         # now dig out the tracker number or jira key in single number format or multiple separated by commas.
-                        r = r = re.compile('(?:[a-zA-Z]+[a-zA-Z0-9]*\-[0-9]+,?)+(,([a-zA-Z]+[a-zA-Z0-9]*\-[0-9]+,?))*,?')
+                        r = re.compile('(?:[a-zA-Z]+[a-zA-Z0-9]*\-[0-9]+,?)+(,([a-zA-Z]+[a-zA-Z0-9]*\-[0-9]+,?))*,?')
                         stories_array = stories.split(',')
                         stories = list(filter(r.match, stories_array))
                         for story in stories:

--- a/flow/projecttracking/jira/jira.py
+++ b/flow/projecttracking/jira/jira.py
@@ -357,7 +357,7 @@ class Jira(Project_Tracking):
                     # verify there isn't a embedded bracket, if so just skip this one and keep marching.
                     if stories.find('[') == -1:  # there is a nested starting bracket
                         # now dig out the tracker number or jira key in single number format or multiple separated by commas.
-                        r = re.compile('(?:[a-zA-Z0-9]+\-[0-9]+,?)+(,([a-zA-Z0-9]+\-[0-9]+,?))*,?'
+                        r = r = re.compile('(?:[a-zA-Z]+[a-zA-Z0-9]*\-[0-9]+,?)+(,([a-zA-Z]+[a-zA-Z0-9]*\-[0-9]+,?))*,?')
                         stories_array = stories.split(',')
                         stories = list(filter(r.match, stories_array))
                         for story in stories:


### PR DESCRIPTION
For projects that contains number in the projectKeys, flow is not able to list out the jira ids from commit messages.
This pr updates regex to accept projectKeys with numericals. Attached is the validation of the regex:
<img width="1485" alt="385524104-8d91df38-0d15-4280-9826-64a363040fad" src="https://github.com/user-attachments/assets/e8cf888f-0d1d-4f66-8f91-a572dfb84cfb">
